### PR TITLE
Fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
         }
       ],
       "vendor": "Mulesoft",
-      "synopsis": "A developert tool to test a HTTP request"
+      "synopsis": "A developer tool to test a HTTP request"
     },
     "win": {
       "target": [


### PR DESCRIPTION
This fixes a minor typo in the description displayed when installing the package on Linux (screenshot below), found on the following path : `build` > `linux` > `synopsis`

![screenshot from 2017-12-13 14-44-39](https://user-images.githubusercontent.com/14823737/33966353-2e33848c-e014-11e7-81bb-afde09699bc6.png)
