### PR TITLE
Bugfix: Context menu not removed on multiple right-click

### DIFF
--- a/scripts/renderer/context-menu.js
+++ b/scripts/renderer/context-menu.js
@@ -78,6 +78,7 @@ class ArcContextMenu {
     }
     if (actions.length) {
       this._lastTarget = target;
+      this.removeActions();
       this.renderActions(actions, {
         x: e.x,
         y: e.y


### PR DESCRIPTION
When you right-click multiple times on the tab it creates multiple context menu and loses the reference to the previous created menu, so when you finally click an action it will only remove the last created and leave opens all the others.

This fix simply remove the previous context menu before creating the new one.