### PR TITLE
fix: fixes #241 - unable to log in to Google

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -684,9 +684,9 @@
       }
     },
     "@advanced-rest-client/electron-session-state": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@advanced-rest-client/electron-session-state/-/electron-session-state-2.1.0.tgz",
-      "integrity": "sha512-mmfgIfTbgRf231+qiWpv4/d/bMR0df1cfpqq7newLpKXq5+/i4YtJE9kPKCEyu19NFDjPnHh8SkWFaQJv8SHRA==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@advanced-rest-client/electron-session-state/-/electron-session-state-2.1.1.tgz",
+      "integrity": "sha512-QNtqBX08+26bnTdpZ1VqWGYWu8VMyWru0dk5dXOv3r3XtRMPhH06HSg5YTvRNEC094bqVWWEyoG8ox8tRf9QRg==",
       "requires": {
         "@advanced-rest-client/arc-electron-helpers": "^1.1.1",
         "@advanced-rest-client/cookie-parser": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "advanced-rest-client",
-  "version": "15.0.2",
+  "version": "15.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "advanced-rest-client",
   "description": "The Advanced REST Client desktop application.",
-  "version": "15.0.2",
+  "version": "15.0.3",
   "homepage": "https://advancedrestclient.com",
   "license": "Apache-2.0",
   "author": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@advanced-rest-client/electron-drive": "^0.4.0",
     "@advanced-rest-client/electron-oauth2": "^2.1.2",
     "@advanced-rest-client/electron-request": "^2.2.4",
-    "@advanced-rest-client/electron-session-state": "^2.1.0",
+    "@advanced-rest-client/electron-session-state": "^2.1.1",
     "amf-client-js": "^4.0.6",
     "camelcase": "^5.3.1",
     "codemirror": "^5.52.0",


### PR DESCRIPTION
fixes #241

It's similar change to the one introduced for OAuth 2 provided where Google was rejecting requests from the Electron windows. The same was happening for the web session window.